### PR TITLE
Add robust date parsing with tests

### DIFF
--- a/tests/test_date_parsing.py
+++ b/tests/test_date_parsing.py
@@ -1,0 +1,55 @@
+import os
+import sys
+from datetime import datetime, date
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from wordle_logs import parse_timestamp, WordleLog
+
+
+@pytest.mark.parametrize(
+    "timestamp_str, expected",
+    [
+        ("03/25/24 07:30 PM", datetime(2024, 3, 25, 19, 30)),
+        ("03/25/2024 19:30", datetime(2024, 3, 25, 19, 30)),
+        ("25/03/24 19:30", datetime(2024, 3, 25, 19, 30)),
+        ("25/03/24 07:30:15 PM", datetime(2024, 3, 25, 19, 30, 15)),
+        ("25/03/2024 19:30:15", datetime(2024, 3, 25, 19, 30, 15)),
+        ("05/14/25 8:12\u00a0AM", datetime(2025, 5, 14, 8, 12)),
+    ],
+)
+def test_parse_timestamp(timestamp_str, expected):
+    assert parse_timestamp(timestamp_str) == expected
+
+
+def test_parse_lines_supports_varied_dates():
+    start = SimpleNamespace(value=date(2024, 3, 25))
+    end = SimpleNamespace(value=date(2024, 3, 25))
+    log = WordleLog(start, end)
+    lines = [
+        "25/03/24, 19:30:15 - Alice: Wordle 123 4/6",
+        "",
+        "⬛⬛⬛⬛🟨",
+    ]
+    log.parse_lines(lines)
+    assert "Alice" in log.users
+    game = log.users["Alice"].games[0]
+    assert game.date == datetime(2024, 3, 25, 19, 30, 15)
+
+
+def test_parse_lines_with_nonbreaking_space():
+    start = SimpleNamespace(value=date(2025, 5, 14))
+    end = SimpleNamespace(value=date(2025, 5, 14))
+    log = WordleLog(start, end)
+    lines = [
+        "05/14/25, 8:12\u00a0AM - John Smith: Wordle 1,425 5/6",
+        "",
+        "⬛⬛⬛⬛🟨",
+    ]
+    log.parse_lines(lines)
+    assert "John Smith" in log.users
+    game = log.users["John Smith"].games[0]
+    assert game.date == datetime(2025, 5, 14, 8, 12)
+    assert game.puzzle_number == 1425

--- a/wordle_logs.py
+++ b/wordle_logs.py
@@ -1,6 +1,31 @@
 from wordle_users import WordleUser
 from datetime import datetime
 
+
+def parse_timestamp(timestamp_str):
+    """Parse a timestamp string in several common formats.
+
+    Supports both US (month/day/year) and international (day/month/year)
+    ordering, 12- or 24-hour clocks, and optional seconds. Any irregular
+    whitespace (including non‑breaking spaces) is normalized before parsing.
+    """
+
+    # Collapse all whitespace characters to single regular spaces to handle
+    # non-breaking spaces or duplicate spacing found in some chat exports.
+    timestamp_str = " ".join(timestamp_str.split())
+
+    date_patterns = ["%m/%d/%y", "%d/%m/%y", "%m/%d/%Y", "%d/%m/%Y"]
+    time_patterns = ["%H:%M", "%H:%M:%S", "%I:%M %p", "%I:%M:%S %p"]
+
+    for d in date_patterns:
+        for t in time_patterns:
+            fmt = f"{d} {t}"
+            try:
+                return datetime.strptime(timestamp_str, fmt)
+            except ValueError:
+                continue
+    raise ValueError(f"Unrecognized date format: {timestamp_str}")
+
 class WordleLog:
     def __init__(self, startdate, enddate):
         self.users = {}
@@ -36,13 +61,11 @@ class WordleLog:
                       continue
 
 
-                    time_part = time_and_rest[0].replace('\u202f', ' ').strip()
+                    # Normalize any exotic whitespace in the time component
+                    time_part = " ".join(time_and_rest[0].split())
                     timestamp_str = f"{date_part} {time_part}"
 
-                    try:
-                        timestamp = datetime.strptime(timestamp_str, "%m/%d/%y %I:%M %p")
-                    except ValueError:
-                        timestamp = datetime.strptime(timestamp_str, "%m/%d/%y %H:%M")
+                    timestamp = parse_timestamp(timestamp_str)
 
                     # ✅ Filter by date range
                     if self.start_date.value and timestamp.date() < self.start_date.value:


### PR DESCRIPTION
## Summary
- normalize whitespace in timestamps to handle non-breaking spaces and duplicate spaces
- test timestamp and log parsing with non-breaking space examples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895c63238b4832aaabee3dd2d74e63d