### PR TITLE
Ignore group addition system messages

### DIFF
--- a/wordle_logs.py
+++ b/wordle_logs.py
@@ -109,6 +109,10 @@ class WordleLog:
           else:
               try:
                     meta = line.split(' - ', 1)[1]
+                    # Ignore system messages like "X added you to a group"
+                    if "added you to" in meta.lower():
+                        i += 1
+                        continue
                     sender, rest = meta.split(':', 1)
                     user = self.get_or_create_user(sender.strip())
                     user.add_chat()
@@ -116,7 +120,7 @@ class WordleLog:
               except Exception as e:
                     pass
                     # print(f"Failed to parse Wordle message: {line}\nError: {e}")
-              
+
               i += 1
 
 


### PR DESCRIPTION
## Summary
- ignore system messages like "X added you to a group" when parsing chat logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6895d7d7635c832aaa1dfaf7e916ed3b